### PR TITLE
fix build for node version 10 (dependency upgrade -> "nan": "^2.10.0")

### DIFF
--- a/libxml.cpp
+++ b/libxml.cpp
@@ -70,7 +70,7 @@ NAN_METHOD(Libxml::New) {
     const int argc = 1;
     Local<Value> argv[argc] = {info[0]};
     Local<Function> cons = Nan::New(constructor());
-    info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+    info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
   }
 }
 


### PR DESCRIPTION
I just found this similar issue and fix in another package here: https://github.com/noble/node-bluetooth-hci-socket/issues/84#issuecomment-391951781

The same seems to work here, to make it build with Node v10. Hope it does not break anything with earlier versions, as long as they update the NaN dependency to ^2.10.